### PR TITLE
allow launch-agent version pinning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,6 @@ workflows:
     jobs:
       - runner-job
       - deploy-in-minikube
-      - verify-job-success:
-          requires:
-            - runner-job
-
 
 ###################
 # Job Definitions #
@@ -57,7 +53,7 @@ jobs:
             DEBIAN_FRONTEND=noninteractive
             sudo apt-get update -y
             sudo apt-get install apt-transport-https
-            sudo apt install -y virtualbox
+            sudo apt install -y virtualbox jq
             sudo snap install kubectl --classic
             sudo snap install helm --classic
 
@@ -73,14 +69,7 @@ jobs:
           name: install helm chart
           command: |
             helm install runner . --set image.tag=<< pipeline.parameters.runner-image >> --set runnerToken=$K8S_RUNNER_TOKEN --set resourceClass=$K8S_RUNNER_RESOURCE
-            #      - run:
-            #          name: wait for completed task
-            #          command: |
-            #            timeout 5m ./scripts/wait_for_task_complete.sh
-            #            sleep 5s
-
-  verify-job-success:
-    docker:
-      - image: alpine:latest
-    steps:
-      - run: echo "success"
+      - run:
+          name: wait for runner job completion
+          command: |
+            timeout 5m ./scripts/wait_for_task_complete.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ workflows:
     jobs:
       - runner-job
       - deploy-in-minikube
+      - verify-job-success:
+          requires:
+            - runner-job
+
 
 ###################
 # Job Definitions #
@@ -69,8 +73,14 @@ jobs:
           name: install helm chart
           command: |
             helm install runner . --set image.tag=<< pipeline.parameters.runner-image >> --set runnerToken=$K8S_RUNNER_TOKEN --set resourceClass=$K8S_RUNNER_RESOURCE
-      - run:
-          name: wait for completed task
-          command: |
-            timeout 5m ./scripts/wait_for_task_complete.sh
-            sleep 5s
+            #      - run:
+            #          name: wait for completed task
+            #          command: |
+            #            timeout 5m ./scripts/wait_for_task_complete.sh
+            #            sleep 5s
+
+  verify-job-success:
+    docker:
+      - image: alpine:latest
+    steps:
+      - run: echo "success"

--- a/scripts/wait_for_task_complete.sh
+++ b/scripts/wait_for_task_complete.sh
@@ -3,7 +3,8 @@
 count=0
 while [ $count -ne 5 ]
 do
-  count=$(kubectl get pods --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | xargs -n1 kubectl logs | grep -c 'Reporting task end')
+  echo "$(kubectl get pods --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')"
+  count=$(kubectl get pods --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | xargs -n1 kubectl logs -p| grep -c 'Reporting task end')
   echo "waiting, current count: $count"
   sleep 5
 done

--- a/scripts/wait_for_task_complete.sh
+++ b/scripts/wait_for_task_complete.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
-
-count=0
-while [ $count -ne 5 ]
+while true;
 do
-  echo "$(kubectl get pods --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')"
-  count=$(kubectl get pods --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | xargs -n1 kubectl logs -p| grep -c 'Reporting task end')
-  echo "waiting, current count: $count"
-  sleep 5
+  job_status=$(curl --request GET --url "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" --header "Circle-Token: $CCI_API_TOKEN" | jq -c '.items[] | select (.name | contains("runner-job")).status')
+
+  echo "Test job status is $job_status"
+
+  if [[ "$job_status" == '"success"' ]]; then
+    exit 0
+  else
+    sleep 10
+  fi
 done

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -43,6 +43,11 @@ spec:
                 secretKeyRef:
                   key: runnerToken
                   name: config-values
+            {{- if .Values.agentVersion }}
+            - name: "agent_version"
+              value: "{{ .Values.agentVersion }}"
+
+            {{- end }}
           livenessProbe:
             exec:
               command:

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,9 @@ resourceClass: ""
 # https://circleci.com/docs/2.0/runner-installation/
 runnerToken: ""
 
+# The agent version to use for CircleCI Enterprise installations
+agentVersion: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Allow the use of the `agent_version` environment variable to pin the launch-agent version for CCI server installs