### PR TITLE
Optional secret creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ jobs:
       - run: echo "Hello from my custom runner!"
 ```
 
+### Setup with Optional Secret Creation
+There may be cases where you do not want Helm to create the Secret resource for you. One case would be if you were using a GitOps deployment tool such as ArgoCD or Flux. In these cases you would need to create a secret manually in the same namespace and cluster where the Helm managed runner resources will be deployed.
+1. Create the secret
+```bash
+$ kubectl create secret generic config-values \
+  --namespace your-namespace
+  --from-literal resourceClass=$CIRCLECI_RUNNER_RESOURCE_CLASS
+  --from-literal runnerToken=$CIRCLECI_RUNNER_RESOURCE_CLASS
+```
+2. Install the Helm chart
+```bash
+$ helm install "circleci-runner" ./ \
+  --set configSecret.create=false \
+  --namespace your-namespace
+```
+
 ## Support Scope
 - Customers who modify the chart beyond values in `values.yaml` do so at their own risk. The type of support CircleCI provides for those customizations will be limited.
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ There may be cases where you do not want Helm to create the Secret resource for 
 1. Create the secret
 ```bash
 $ kubectl create secret generic config-values \
-  --namespace your-namespace
-  --from-literal resourceClass=$CIRCLECI_RUNNER_RESOURCE_CLASS
+  --namespace your-namespace \
+  --from-literal resourceClass=$CIRCLECI_RUNNER_RESOURCE_CLASS \
   --from-literal runnerToken=$CIRCLECI_RUNNER_TOKEN
 ```
 2. Install the Helm chart

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ There may be cases where you do not want Helm to create the Secret resource for 
 $ kubectl create secret generic config-values \
   --namespace your-namespace
   --from-literal resourceClass=$CIRCLECI_RUNNER_RESOURCE_CLASS
-  --from-literal runnerToken=$CIRCLECI_RUNNER_RESOURCE_CLASS
+  --from-literal runnerToken=$CIRCLECI_RUNNER_TOKEN
 ```
 2. Install the Helm chart
 ```bash

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -37,12 +37,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: resourceClass
-                  name: config-values
+                  name: {{ .Values.configSecret.name }}
             - name: "CIRCLECI_API_TOKEN"
               valueFrom:
                 secretKeyRef:
                   key: runnerToken
-                  name: config-values
+                  name: {{ .Values.configSecret.name }}
             {{- if .Values.agentVersion }}
             - name: "agent_version"
               value: "{{ .Values.agentVersion }}"

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,7 +1,9 @@
+{{- if .Values.configSecret.create -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: config-values
+  name: {{ .Values.configSecret.name }}
 data:
   resourceClass: {{ .Values.resourceClass | b64enc }}
   runnerToken: {{ .Values.runnerToken | b64enc }}
+{{- end }} 

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,10 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "launch-agent"
 
+configSecret:
+  create: true
+  name: config-values
+
 # Refers to the resource class you created for your runner. See:
 # https://circleci.com/docs/2.0/runner-installation/?section=executors-and-images#authentication
 resourceClass: ""
@@ -50,3 +54,4 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+


### PR DESCRIPTION
When installing the circleci-runner using a GitOps tool like ArgoCD or Flux it is preferable to not create the secret. This PR introduces configuration to allow you to skip secret creation with Helm and it would be expected that you would create the Secret resource manually with the correct values. Documentation in the README has also been updated to provide instructions on how this would be done.