### PR TITLE
Set minikube driver to docker explicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           name: minikube start
           command: |
             minikube version
-            minikube start
+            minikube start --driver=docker
       - run:
           name: install helm chart
           command: |


### PR DESCRIPTION
For some pipeline runs the `docker` driver is not being detected by `minikube`, leading to the `virtualbox` driver being selected. As the pipeline is executing in a VM already this fails due to missing `VT-x`.

Setting the driver flag explicitly forces `minikube` to use the `docker` driver as expected 