### PR TITLE
feat(deployment): add environment variables to launch agent

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -46,7 +46,10 @@ spec:
             {{- if .Values.agentVersion }}
             - name: "agent_version"
               value: "{{ .Values.agentVersion }}"
-
+            {{- end }}
+            {{- range $k, $v := .Values.launchAgentEnvironmentVariables }}
+            - name: "{{ $k }}"
+              value: "{{ $v }}"
             {{- end }}
           livenessProbe:
             exec:

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,13 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "launch-agent"
 
+# These environment variables will be passed into the Launch Agent container
+# For example, setting the `runner.mode` (from https://circleci.com/docs/2.0/runner-config-reference/):
+#
+# launchAgentEnvironmentVariables:
+#   LAUNCH_AGENT_RUNNER_MODE: single-task
+launchAgentEnvironmentVariables: {}
+
 configSecret:
   create: true
   name: config-values


### PR DESCRIPTION
Allow adding environment variables to the launch agent.

Following the official [config reference guide](https://circleci.com/docs/2.0/runner-config-reference/), I wanted to set the `runner.mode` configuration value. This uses the `LAUNCH_AGENT_RUNNER_MODE` environment variable, which there was no option to do using the deployment.yaml template file.

This PR allows setting environment variables on the launch agent container. By default, **no new variables are added**,  (the default is an empty map), but by setting `launchAgentEnvironmentVariables.<ENV_VAR>` to a value, it will be passed into the container. For example:

```yaml
launchAgentEnvironmentVariables:
    LAUNCH_AGENT_RUNNER_MODE: single-task
``` 