### PR TITLE
allow use of environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ jobs:
       - run: echo "Hello from my custom runner!"
 ```
 
+### Set Environment Variables
+Environment variables can be configured in `env` section of the `values.yaml` file. Environment variables can be used to further configure the CircleCI Runner using the environment variables described in the [configuration reference page](https://circleci.com/docs/2.0/runner-config-reference/).
+ 
 ### Setup with Optional Secret Creation
 There may be cases where you do not want Helm to create the Secret resource for you. One case would be if you were using a GitOps deployment tool such as ArgoCD or Flux. In these cases you would need to create a secret manually in the same namespace and cluster where the Helm managed runner resources will be deployed.
 1. Create the secret

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -46,7 +46,10 @@ spec:
             {{- if .Values.agentVersion }}
             - name: "agent_version"
               value: "{{ .Values.agentVersion }}"
-
+            {{- end }}
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value }}
             {{- end }}
           livenessProbe:
             exec:

--- a/values.yaml
+++ b/values.yaml
@@ -55,3 +55,6 @@ tolerations: []
 
 affinity: {}
 
+env:
+  - name: "MY_VAR"
+    value: "the value of MY_VAR"


### PR DESCRIPTION
Allow environment variables to be added to the launch-agent container. 

Tested locally - verifying the example variable set was populated in the deployment. 

README updated detailing how to set environment variables, and a link to the configuration reference for runner. 