### PR TITLE
Enabling overriding values

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -47,6 +47,10 @@ spec:
             - name: "agent_version"
               value: "{{ .Values.agentVersion }}"
             {{- end }}
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value }}
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           resources:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: circleci-runner
-      automountServiceAccountToken: false
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -47,18 +47,8 @@ spec:
             - name: "agent_version"
               value: "{{ .Values.agentVersion }}"
             {{- end }}
-            {{- range .Values.env }}
-            - name: {{ .name }}
-              value: {{ .value }}
-            {{- end }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - ps -ef | grep circleci-launch-agent
-            initialDelaySeconds: 3
-            periodSeconds: 5
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: circleci-runner
-automountServiceAccountToken: false
+automountServiceAccountToken:  {{ .Values.automountServiceAccountToken }}

--- a/values.yaml
+++ b/values.yaml
@@ -49,6 +49,18 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+
+automountServiceAccountToken: false
+
+livenessProbe:
+  exec:
+    command:
+      - /bin/sh
+      - -c
+      - ps -ef | grep circleci-launch-agent
+  initialDelaySeconds: 3
+  periodSeconds: 5
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
I would like to make the following changes:

automountServiceAccountToken and liveness probe is configurable by moving default values to value.yaml. This allows user to override these values if needed, but will also work out of the box as it had prior to the change.