### PR TITLE
Fix minikube start failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
       - run:
           name: minikube start
           command: |
+            time docker version
             minikube version
             minikube start --driver=docker
       - run:


### PR DESCRIPTION
Not really sure why, but `docker version` is really slow the first time it's called. We can see in this job that it took 9 seconds: https://app.circleci.com/pipelines/github/CircleCI-Public/circleci-runner-k8s/844/workflows/bb51ad0e-29ee-4633-890d-f5944e448b6f/jobs/1694/parallel-runs/0/steps/0-103

`minikube` calls this too to check the healthiness of `docker` before it starts. However, it times out if this check exceeds 6 seconds: https://github.com/kubernetes/minikube/blob/master/pkg/minikube/registry/drvs/docker/docker.go#L96-L106