### PR TITLE
feat: support secret references in env

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ jobs:
 
 ### Set Environment Variables
 Environment variables can be configured in `env` section of the `values.yaml` file. Environment variables can be used to further configure the CircleCI Runner using the environment variables described in the [configuration reference page](https://circleci.com/docs/2.0/runner-config-reference/).
+It's also possible to add additional Kubernetes secret references (see example in `env` section of `values.yaml`.
  
 ### Setup with Optional Secret Creation
 There may be cases where you do not want Helm to create the Secret resource for you. One case would be if you were using a GitOps deployment tool such as ArgoCD or Flux. In these cases you would need to create a secret manually in the same namespace and cluster where the Helm managed runner resources will be deployed.

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -49,7 +49,14 @@ spec:
             {{- end }}
             {{- range .Values.env }}
             - name: {{ .name }}
+              {{- if .value }}
               value: {{ .value }}
+              {{- else if .valueFrom.secretKeyRef }}
+              valueFrom:
+                secretKeyRef:
+                  key: {{ .valueFrom.secretKeyRef.key }}
+                  name: {{ .valueFrom.secretKeyRef.name }}
+              {{- end }}
             {{- end }}
           livenessProbe:
             exec:

--- a/values.yaml
+++ b/values.yaml
@@ -61,6 +61,12 @@ tolerations: []
 
 affinity: {}
 
-env:
-  - name: "MY_VAR"
-    value: "the value of MY_VAR"
+env: {}
+  # Example:
+  # - name: MY_VAR
+  #   value: "the value of MY_VAR"
+  # - name: FOO_SECRET
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: foo
+  #       name: bar


### PR DESCRIPTION
- Add support for valueFrom.secretKeyRef in env dictionary. It might be possible to make this support more different options, but this at least supports adding additional Kube secrets to the environment via the chart
- Leave commented example in `values.yaml`, but take out default `MY_VAR` - this technically changes the behavior of the module, but I think shouldn't be breaking in practice
- Update docs